### PR TITLE
Munge filenames before putting

### DIFF
--- a/bulkS3upload.go
+++ b/bulkS3upload.go
@@ -84,7 +84,7 @@ func copyWorker(bucket string, url string, accessID string, secretKey string, ss
 		stringArray := strings.Split(filePath,"/")
 		objectPath := stringArray[0] + "/" + stringArray[1] + "/" + stringArray[2] + "/" + stringArray[3]
 		fullPath := rootDir + filePath
-		fileinfo, err := os.Stat(fullPath)
+		fileinfo, _ := os.Stat(fullPath)
 		_, err = minioClient.FPutObject(ctx, bucket, objectPath, fullPath, minio.PutObjectOptions{})
 		if err != nil {
 			log.Printf(err.Error())

--- a/bulkS3upload.go
+++ b/bulkS3upload.go
@@ -32,7 +32,6 @@ type CopyResult struct {
 	path  string
 	bytes int64
 	err   error
-	etag  string
 }
 
 // Configuration defaults for location of file and default settings
@@ -86,12 +85,11 @@ func copyWorker(bucket string, url string, accessID string, secretKey string, ss
 		objectPath := stringArray[0] + "/" + stringArray[1] + "/" + stringArray[2] + "/" + stringArray[3]
 		fullPath := rootDir + filePath
 		fileinfo, err := os.Stat(fullPath)
-		uploadInfo, err := minioClient.FPutObject(ctx, bucket, objectPath, fullPath, minio.PutObjectOptions{})
+		_, err := minioClient.FPutObject(ctx, bucket, objectPath, fullPath, minio.PutObjectOptions{})
 		if err != nil {
 			log.Printf(err.Error())
 		}
-//		log.Printf("ETag: %s VersionID: %s", uploadInfo.ETag,uploadInfo.VersionID)
-		nodeStats <- CopyResult{path: filePath, bytes: fileinfo.Size(), err: err, etag: uploadInfo.ETag}
+		nodeStats <- CopyResult{path: filePath, bytes: fileinfo.Size(), err: err}
 		count++
 	}
 }

--- a/bulkS3upload.go
+++ b/bulkS3upload.go
@@ -88,7 +88,7 @@ func copyWorker(bucket string, url string, accessID string, secretKey string, ss
 		if err != nil {
 			log.Printf(err.Error())
 		}
-		log.Printf(uploadInfo)
+		log.Printf("ETag: %s VersionID: %s", uploadInfo.ETag,uploadInfo.VersionID)
 		nodeStats <- CopyResult{path: filePath, bytes: 0, err: err}
 		count++
 	}

--- a/bulkS3upload.go
+++ b/bulkS3upload.go
@@ -85,12 +85,13 @@ func copyWorker(bucket string, url string, accessID string, secretKey string, ss
 		stringArray := strings.Split(filePath,"/")
 		objectPath := stringArray[0] + "/" + stringArray[1] + "/" + stringArray[2] + "/" + stringArray[3]
 		fullPath := rootDir + filePath
+		fileinfo, err := os.Stat(fullPath)
 		uploadInfo, err := minioClient.FPutObject(ctx, bucket, objectPath, fullPath, minio.PutObjectOptions{})
 		if err != nil {
 			log.Printf(err.Error())
 		}
 //		log.Printf("ETag: %s VersionID: %s", uploadInfo.ETag,uploadInfo.VersionID)
-		nodeStats <- CopyResult{path: filePath, bytes: 0, err: err, etag: uploadInfo.ETag}
+		nodeStats <- CopyResult{path: filePath, bytes: fileinfo.Size(), err: err, etag: uploadInfo.ETag}
 		count++
 	}
 }

--- a/bulkS3upload.go
+++ b/bulkS3upload.go
@@ -15,6 +15,7 @@ import (
 	"bufio"
 	"fmt"
 	"github.com/minio/minio-go"
+	"github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"log"

--- a/bulkS3upload.go
+++ b/bulkS3upload.go
@@ -84,10 +84,13 @@ func copyWorker(bucket string, url string, accessID string, secretKey string, ss
 		stringArray := strings.Split(filePath,"/")
 		objectPath := stringArray[0] + "/" + stringArray[1] + "/" + stringArray[2] + "/" + stringArray[3]
 		fullPath := rootDir + filePath
-		fileinfo, _ := os.Stat(fullPath)
-		_, err = minioClient.FPutObject(ctx, bucket, objectPath, fullPath, minio.PutObjectOptions{})
-		if err != nil {
-			log.Printf(err.Error())
+		fileinfo, statErr := os.Stat(fullPath)
+		if statErr != nil {
+			log.Printf("error statting file %s",fullPath)
+		}
+		_, minioErr := minioClient.FPutObject(ctx, bucket, objectPath, fullPath, minio.PutObjectOptions{})
+		if minioErr != nil {
+			log.Printf(minioErr.Error())
 		}
 		nodeStats <- CopyResult{path: filePath, bytes: fileinfo.Size(), err: err}
 		count++

--- a/bulkS3upload.go
+++ b/bulkS3upload.go
@@ -88,7 +88,7 @@ func copyWorker(bucket string, url string, accessID string, secretKey string, ss
 		if err != nil {
 			log.Printf(err.Error())
 		}
-		nodeStats <- CopyResult{path: filePath, bytes: bytes, err: err}
+		nodeStats <- CopyResult{path: filePath, bytes: 0, err: err}
 		count++
 	}
 }

--- a/bulkS3upload.go
+++ b/bulkS3upload.go
@@ -77,8 +77,10 @@ func copyWorker(bucket string, url string, accessID string, secretKey string, ss
 	}
 	count := 0
 	for filePath := range files {
+		stringArray := strings.Split(filePath,"/")
+		objectPath := stringArray[0] + "/" + stringArray[1] + "/" + stringarray[2] + "/" + stringarray[3]
 		fullPath := rootDir + filePath
-		bytes, err := minioClient.FPutObject(bucket, filePath, fullPath, minio.PutObjectOptions{})
+		bytes, err := minioClient.FPutObject(bucket, objectPath, fullPath, minio.PutObjectOptions{})
 		if err != nil {
 			log.Printf(err.Error())
 		}

--- a/bulkS3upload.go
+++ b/bulkS3upload.go
@@ -32,6 +32,7 @@ type CopyResult struct {
 	path  string
 	bytes int64
 	err   error
+	etag  string
 }
 
 // Configuration defaults for location of file and default settings
@@ -88,8 +89,8 @@ func copyWorker(bucket string, url string, accessID string, secretKey string, ss
 		if err != nil {
 			log.Printf(err.Error())
 		}
-		log.Printf("ETag: %s VersionID: %s", uploadInfo.ETag,uploadInfo.VersionID)
-		nodeStats <- CopyResult{path: filePath, bytes: 0, err: err}
+//		log.Printf("ETag: %s VersionID: %s", uploadInfo.ETag,uploadInfo.VersionID)
+		nodeStats <- CopyResult{path: filePath, bytes: 0, err: err, etag: uploadInfo.ETag}
 		count++
 	}
 }

--- a/bulkS3upload.go
+++ b/bulkS3upload.go
@@ -69,7 +69,10 @@ func copyWorker(bucket string, url string, accessID string, secretKey string, ss
 
 	defer wg.Done()
 
-	minioClient, err := minio.New(url, accessID, secretKey, ssl)
+	minioClient, err := minio.New(url, &minio.Options{
+		Creds: credentials.NewStaticV4(accessID, secretKey, ""),
+		Secure: ssl,
+	})
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/bulkS3upload.go
+++ b/bulkS3upload.go
@@ -24,8 +24,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/spf13/pflag"
-	"github.com/spf13/viper"
 )
 
 type CopyResult struct {

--- a/bulkS3upload.go
+++ b/bulkS3upload.go
@@ -85,7 +85,7 @@ func copyWorker(bucket string, url string, accessID string, secretKey string, ss
 		objectPath := stringArray[0] + "/" + stringArray[1] + "/" + stringArray[2] + "/" + stringArray[3]
 		fullPath := rootDir + filePath
 		fileinfo, err := os.Stat(fullPath)
-		_, err := minioClient.FPutObject(ctx, bucket, objectPath, fullPath, minio.PutObjectOptions{})
+		_, err = minioClient.FPutObject(ctx, bucket, objectPath, fullPath, minio.PutObjectOptions{})
 		if err != nil {
 			log.Printf(err.Error())
 		}

--- a/bulkS3upload.go
+++ b/bulkS3upload.go
@@ -84,10 +84,11 @@ func copyWorker(bucket string, url string, accessID string, secretKey string, ss
 		stringArray := strings.Split(filePath,"/")
 		objectPath := stringArray[0] + "/" + stringArray[1] + "/" + stringArray[2] + "/" + stringArray[3]
 		fullPath := rootDir + filePath
-		bytes, err := minioClient.FPutObject(ctx, bucket, objectPath, fullPath, minio.PutObjectOptions{})
+		uploadInfo, err := minioClient.FPutObject(ctx, bucket, objectPath, fullPath, minio.PutObjectOptions{})
 		if err != nil {
 			log.Printf(err.Error())
 		}
+		log.Printf(uploadInfo)
 		nodeStats <- CopyResult{path: filePath, bytes: 0, err: err}
 		count++
 	}

--- a/bulkS3upload.go
+++ b/bulkS3upload.go
@@ -15,7 +15,7 @@ import (
 	"bufio"
 	"fmt"
 	"github.com/minio/minio-go"
-	"github.com/minio/minio-go/v7/pkg/credentials"
+	"github.com/minio/minio-go/pkg/credentials"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"log"

--- a/bulkS3upload.go
+++ b/bulkS3upload.go
@@ -14,6 +14,7 @@ package main
 import (
 	"bufio"
 	"fmt"
+	"context"
 	"github.com/minio/minio-go"
 	"github.com/minio/minio-go/pkg/credentials"
 	"github.com/spf13/pflag"
@@ -68,6 +69,7 @@ var errorLines = 0
 // and then waits on a channel for file paths that should be copied into the endpoint/bucket
 func copyWorker(bucket string, url string, accessID string, secretKey string, ssl bool, files <-chan string, nodeStats chan<- CopyResult, wg *sync.WaitGroup) {
 
+	ctx := context.Background()
 	defer wg.Done()
 
 	minioClient, err := minio.New(url, &minio.Options{
@@ -82,7 +84,7 @@ func copyWorker(bucket string, url string, accessID string, secretKey string, ss
 		stringArray := strings.Split(filePath,"/")
 		objectPath := stringArray[0] + "/" + stringArray[1] + "/" + stringArray[2] + "/" + stringArray[3]
 		fullPath := rootDir + filePath
-		bytes, err := minioClient.FPutObject(bucket, objectPath, fullPath, minio.PutObjectOptions{})
+		bytes, err := minioClient.FPutObject(ctx, bucket, objectPath, fullPath, minio.PutObjectOptions{})
 		if err != nil {
 			log.Printf(err.Error())
 		}

--- a/bulkS3upload.go
+++ b/bulkS3upload.go
@@ -78,7 +78,7 @@ func copyWorker(bucket string, url string, accessID string, secretKey string, ss
 	count := 0
 	for filePath := range files {
 		stringArray := strings.Split(filePath,"/")
-		objectPath := stringArray[0] + "/" + stringArray[1] + "/" + stringarray[2] + "/" + stringarray[3]
+		objectPath := stringArray[0] + "/" + stringArray[1] + "/" + stringArray[2] + "/" + stringArray[3]
 		fullPath := rootDir + filePath
 		bytes, err := minioClient.FPutObject(bucket, objectPath, fullPath, minio.PutObjectOptions{})
 		if err != nil {


### PR DESCRIPTION
The blobstore expects a node at (for example) 5addfec2-1196-427f-a346-a12168b48a2e to be in S3 at 5a/dd/fe/5addfec2-1196-427f-a346-a12168b48a2e , but in Shock it is stored at 5a/dd/fe/5addfec2-1196-427f-a346-a12168b48a2e/5addfec2-1196-427f-a346-a12168b48a2e5addfec2-1196-427f-a346-a12168b48a2e.data .  So we have to munge the S3 destination before putting it.

In addition, the MinIO Go API changed since we wrote bulkS3upload, including (apparently) no longer returning the number of bytes uploaded, so we still need a way of reporting that (probably can just get from the on-disk file and assume that bytes transferred is the same).