### PR TITLE
Fix error reporting when source file missing

### DIFF
--- a/bulkS3upload.go
+++ b/bulkS3upload.go
@@ -88,15 +88,18 @@ func copyWorker(bucket string, url string, accessID string, secretKey string, ss
 		fileSize := int64(0)
 		if statErr != nil {
 			log.Printf("error statting file %s",fullPath)
-		} else {
-			fileSize = fileinfo.Size()
+			nodeStats <- CopyResult{path: filePath, bytes: fileSize, err: statErr}
+			continue
 		}
 		
 		_, minioErr := minioClient.FPutObject(ctx, bucket, objectPath, fullPath, minio.PutObjectOptions{})
 		if minioErr != nil {
 			log.Printf(minioErr.Error())
+		} else {
+			fileSize = fileinfo.Size()
 		}
-		nodeStats <- CopyResult{path: filePath, bytes: fileSize, err: err}
+
+		nodeStats <- CopyResult{path: filePath, bytes: fileSize, err: minioErr}
 		count++
 	}
 }

--- a/bulkS3upload.go
+++ b/bulkS3upload.go
@@ -85,11 +85,11 @@ func copyWorker(bucket string, url string, accessID string, secretKey string, ss
 		objectPath := stringArray[0] + "/" + stringArray[1] + "/" + stringArray[2] + "/" + stringArray[3]
 		fullPath := rootDir + filePath
 		fileinfo, statErr := os.Stat(fullPath)
+		fileSize := 0
 		if statErr != nil {
 			log.Printf("error statting file %s",fullPath)
-			fileSize := 0
 		} else {
-			fileSize := fileinfo.Size()
+			fileSize = fileinfo.Size()
 		}
 		
 		_, minioErr := minioClient.FPutObject(ctx, bucket, objectPath, fullPath, minio.PutObjectOptions{})

--- a/bulkS3upload.go
+++ b/bulkS3upload.go
@@ -85,7 +85,7 @@ func copyWorker(bucket string, url string, accessID string, secretKey string, ss
 		objectPath := stringArray[0] + "/" + stringArray[1] + "/" + stringArray[2] + "/" + stringArray[3]
 		fullPath := rootDir + filePath
 		fileinfo, statErr := os.Stat(fullPath)
-		fileSize := 0
+		fileSize := int64(0)
 		if statErr != nil {
 			log.Printf("error statting file %s",fullPath)
 		} else {

--- a/bulkS3upload.go
+++ b/bulkS3upload.go
@@ -87,12 +87,16 @@ func copyWorker(bucket string, url string, accessID string, secretKey string, ss
 		fileinfo, statErr := os.Stat(fullPath)
 		if statErr != nil {
 			log.Printf("error statting file %s",fullPath)
+			fileSize := 0
+		} else {
+			fileSize := fileinfo.Size()
 		}
+		
 		_, minioErr := minioClient.FPutObject(ctx, bucket, objectPath, fullPath, minio.PutObjectOptions{})
 		if minioErr != nil {
 			log.Printf(minioErr.Error())
 		}
-		nodeStats <- CopyResult{path: filePath, bytes: fileinfo.Size(), err: err}
+		nodeStats <- CopyResult{path: filePath, bytes: fileSize, err: err}
 		count++
 	}
 }


### PR DESCRIPTION
When the source file is missing it would throw a panic because it tried to report stats on a file that doesn't exist.  Better handle that so that no bytes and a failure are reported as transferred if there's an error either in the source file or the MinIO put.